### PR TITLE
Converting android modules to jvm modules

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ buildscript {
     classpath libs.anvil.classpath
     classpath libs.ben.classpath
     classpath libs.detekt.classpath
+    classpath libs.jetbrains.compose.classpath
     classpath libs.junit5.android.classpath
     classpath libs.kotlin.classpath
     classpath libs.kotlinter.classpath
@@ -39,7 +40,6 @@ buildscript {
 
 plugins {
   id "com.github.ben-manes.versions" version "0.42.0"
-  id "com.google.devtools.ksp" version "1.7.10-1.0.6"
 }
 
 allprojects {

--- a/ui/galleries/common/impl-wiring/build.gradle
+++ b/ui/galleries/common/impl-wiring/build.gradle
@@ -1,27 +1,12 @@
-apply plugin: "com.android.library"
-apply plugin: "org.jetbrains.kotlin.android"
-
-android {
-  buildFeatures {
-    buildConfig false
-    resValues false
-  }
-
-  compileSdkVersion buildConfig.compileSdk
-
-  defaultConfig {
-    minSdkVersion buildConfig.minSdk
-    targetSdkVersion buildConfig.targetSdk
-  }
-
-  kotlinOptions {
-    freeCompilerArgs += "-Xexplicit-api=strict"
-  }
-}
+apply plugin: "org.jetbrains.kotlin.jvm"
 
 archivesBaseName = "ui-galleries-common-impl-wiring"
 
 dependencies {
   api projects.ui.galleries.common.public
   api projects.ui.galleries.common.impl
+}
+
+kotlin {
+  explicitApi()
 }

--- a/ui/galleries/common/impl-wiring/src/main/AndroidManifest.xml
+++ b/ui/galleries/common/impl-wiring/src/main/AndroidManifest.xml
@@ -1,2 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.adjectivemonk2.pixels.ui.galleries.common.impl.wiring" />

--- a/ui/galleries/common/impl/build.gradle
+++ b/ui/galleries/common/impl/build.gradle
@@ -1,37 +1,5 @@
-apply plugin: "com.android.library"
-apply plugin: "org.jetbrains.kotlin.android"
+apply plugin: "org.jetbrains.kotlin.jvm"
 apply plugin: "com.squareup.anvil"
-
-android {
-  buildFeatures {
-    buildConfig false
-    compose true
-    resValues false
-  }
-
-  compileSdkVersion buildConfig.compileSdk
-
-  composeOptions {
-    kotlinCompilerExtensionVersion libs.versions.compose.get()
-  }
-
-  defaultConfig {
-    minSdkVersion buildConfig.minSdk
-    targetSdkVersion buildConfig.targetSdk
-  }
-
-  kotlinOptions {
-    freeCompilerArgs += "-Xexplicit-api=strict"
-  }
-
-  testOptions {
-    unitTests {
-      all {
-        useJUnitPlatform()
-      }
-    }
-  }
-}
 
 anvil {
   generateDaggerFactories = true
@@ -62,6 +30,8 @@ dependencies {
 }
 
 kotlin {
+  explicitApi()
+
   sourceSets.all {
     languageSettings {
       optIn("com.squareup.workflow1.ui.WorkflowUiExperimentalApi")
@@ -69,3 +39,8 @@ kotlin {
     }
   }
 }
+
+test {
+  useJUnitPlatform()
+}
+

--- a/ui/galleries/common/impl/src/main/AndroidManifest.xml
+++ b/ui/galleries/common/impl/src/main/AndroidManifest.xml
@@ -1,2 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.adjectivemonk2.pixels.ui.galleries.common.impl" />

--- a/ui/galleries/common/public/build.gradle
+++ b/ui/galleries/common/public/build.gradle
@@ -1,22 +1,5 @@
-apply plugin: "com.android.library"
-apply plugin: "org.jetbrains.kotlin.android"
+apply plugin: "org.jetbrains.kotlin.jvm"
 apply plugin: "com.squareup.anvil"
-
-android {
-  buildFeatures {
-    buildConfig false
-    compose true
-    resValues false
-  }
-
-  composeOptions {
-    kotlinCompilerExtensionVersion libs.versions.compose.get()
-  }
-
-  kotlinOptions {
-    freeCompilerArgs += "-Xexplicit-api=strict"
-  }
-}
 
 anvil {
   generateDaggerFactories = true
@@ -27,8 +10,12 @@ archivesBaseName = "ui-galleries-common-public"
 dependencies {
   api projects.model.gallery.public
 
-  api libs.androidx.compose.runtime
+  api libs.jetbrains.compose.runtime
   api libs.workflow.core
 
   implementation libs.dagger.runtime
+}
+
+kotlin {
+  explicitApi()
 }

--- a/ui/galleries/common/public/src/main/AndroidManifest.xml
+++ b/ui/galleries/common/public/src/main/AndroidManifest.xml
@@ -1,2 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.adjectivemonk2.pixels.ui.galleries.common" />


### PR DESCRIPTION
Was making certain modules android libraries because of the the need of compose dependency. Jetbrains publishing the multiplatform variant helps me change the modules from android dependent ones to jvm dependent ones.